### PR TITLE
Prevent constraint violation on objects with restrictive permissions

### DIFF
--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -3629,7 +3629,14 @@ function Add-ObjectAcl {
                         # add all the new ACEs to the specified object
                         ForEach ($ACE in $ACEs) {
                             Write-Verbose "Granting principal $ResolvedPrincipalSID '$($ACE.ObjectType)' rights on $($_.Properties.distinguishedname)"
+                            # resolve the object
                             $Object = [adsi]($_.path)
+                            
+                            # restrict object changes to ACL only
+                            [System.DirectoryServices.DirectoryEntryConfiguration]$SecOptions = $Object.get_Options()
+                            $SecOptions.SecurityMasks = [System.DirectoryServices.SecurityMasks]’Dacl’
+                            
+                            # add ACE
                             $Object.PsBase.ObjectSecurity.AddAccessRule($ACE)
                             $Object.PsBase.commitchanges()
                         }

--- a/Recon/PowerView.ps1
+++ b/Recon/PowerView.ps1
@@ -3634,7 +3634,7 @@ function Add-ObjectAcl {
                             
                             # restrict object changes to ACL only
                             [System.DirectoryServices.DirectoryEntryConfiguration]$SecOptions = $Object.get_Options()
-                            $SecOptions.SecurityMasks = [System.DirectoryServices.SecurityMasks]’Dacl’
+                            $SecOptions.SecurityMasks = [System.DirectoryServices.SecurityMasks]'Dacl'
                             
                             # add ACE
                             $Object.PsBase.ObjectSecurity.AddAccessRule($ACE)


### PR DESCRIPTION
Restrict access to ADSI object so they're only writting to the ACL.
This fixes an issue writting an ACL when you exclusively have `WriteDACL` permission on a object.